### PR TITLE
Allow Trino connections with password

### DIFF
--- a/dev/trino-conf/README.md
+++ b/dev/trino-conf/README.md
@@ -1,0 +1,27 @@
+### Local Trino Cluster with Self-Signed Cert
+ 
+In order to test Trino with user@password you need a local cluster with Basic Auth enabled. 
+
+## First thing, we need a self signed cert.
+```
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout dev/trino-conf/etc/trino-key.pem -out dev/trino-conf/etc/trino-cert.pem -config dev/trino-conf/cert.conf
+cat trino-cert.pem trino-key.pem > trino-combined.pem
+```
+
+## Include https settings in config.properties
+
+Include the following lines in dev/trino-conf/etc/config.properties
+
+```
+http-server.https.enabled=true
+http-server.https.keystore.path=/etc/trino/trino-combined.pem
+http-server.https.keystore.key=<key>
+http-server.authentication.type=PASSWORD
+```
+
+## Create a password.db file
+
+```
+touch dev/trino-conf/etc/password.db
+htpasswd -B -C 10 dev/trino-conf/etc/password.db test
+```

--- a/dev/trino-conf/README.md
+++ b/dev/trino-conf/README.md
@@ -13,10 +13,12 @@ cat dev/trino-conf/etc/trino-cert.pem dev/trino-conf/etc/trino-key.pem > dev/tri
 Include the following lines in dev/trino-conf/etc/config.properties
 
 ```
+http-server.https.port=8443
 http-server.https.enabled=true
 http-server.https.keystore.path=/etc/trino/trino-combined.pem
 http-server.https.keystore.key=<key>
 http-server.authentication.type=PASSWORD
+internal-communication.shared-secret="secret"
 ```
 
 ## Create a password.db file

--- a/dev/trino-conf/README.md
+++ b/dev/trino-conf/README.md
@@ -5,7 +5,7 @@ In order to test Trino with user@password you need a local cluster with Basic Au
 ## First thing, we need a self signed cert.
 ```
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout dev/trino-conf/etc/trino-key.pem -out dev/trino-conf/etc/trino-cert.pem -config dev/trino-conf/cert.conf
-cat trino-cert.pem trino-key.pem > trino-combined.pem
+cat dev/trino-conf/etc/trino-cert.pem dev/trino-conf/etc/trino-key.pem > dev/trino-conf/etc/trino-combined.pem
 ```
 
 ## Include https settings in config.properties

--- a/dev/trino-conf/cert.conf
+++ b/dev/trino-conf/cert.conf
@@ -1,0 +1,17 @@
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = req_ext
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+CN = localhost
+
+[req_ext]
+subjectAltName = @alt_names
+
+[v3_ca]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost

--- a/dev/trino-conf/etc/config.properties
+++ b/dev/trino-conf/etc/config.properties
@@ -1,11 +1,5 @@
 coordinator=true
 node-scheduler.include-coordinator=true
 http-server.http.port=8080
-http-server.https.port=8443
 discovery.uri=http://localhost:8080
-http-server.https.enabled=true
-http-server.https.keystore.path=/etc/trino/trino-combined.pem
-# http-server.https.keystore.key=<key>
-http-server.authentication.type=PASSWORD
 discovery-server.enabled=true
-internal-communication.shared-secret="secret"

--- a/dev/trino-conf/etc/config.properties
+++ b/dev/trino-conf/etc/config.properties
@@ -1,5 +1,11 @@
 coordinator=true
 node-scheduler.include-coordinator=true
 http-server.http.port=8080
+http-server.https.port=8443
 discovery.uri=http://localhost:8080
+http-server.https.enabled=true
+http-server.https.keystore.path=/etc/trino/trino-combined.pem
+# http-server.https.keystore.key=<key>
+http-server.authentication.type=PASSWORD
 discovery-server.enabled=true
+internal-communication.shared-secret="secret"

--- a/dev/trino-conf/etc/jvm.config
+++ b/dev/trino-conf/etc/jvm.config
@@ -1,7 +1,8 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
+-XX:+UnlockDiagnosticVMOptions 
+-XX:G1NumCollectionsKeepPinned=10000000
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+HeapDumpOnOutOfMemoryError

--- a/dev/trino-conf/etc/password-authenticator.properties
+++ b/dev/trino-conf/etc/password-authenticator.properties
@@ -1,0 +1,2 @@
+password-authenticator.name=file
+file.password-file=/etc/trino/password.db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
         image: 'trinodb/trino:450'
         hostname: trino
         ports:
-            - '8080:8080'
+            - '8081:8080'
             - '8443:8443'
         volumes:
             - ./dev/trino-conf/etc:/etc/trino:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,10 +89,11 @@ services:
 
     trino:
         container_name: dd-trino
-        image: 'trinodb/trino:389'
+        image: 'trinodb/trino:450'
         hostname: trino
         ports:
-            - '8081:8080'
+            - '8080:8080'
+            - '8443:8443'
         volumes:
             - ./dev/trino-conf/etc:/etc/trino:ro
         networks:

--- a/sqeleton/databases/trino.py
+++ b/sqeleton/databases/trino.py
@@ -39,8 +39,6 @@ class Trino(presto.Presto):
     dialect = Dialect()
     CONNECT_URI_HELP = "trino://<user>@<host>/<catalog>/<schema>"
     CONNECT_URI_PARAMS = ["catalog", "schema"]
-    # CONNECT_URI_HELP = "trino://<user>:<password>@<host>:<port>/<catalog>/<schema>"
-    # CONNECT_URI_PARAMS = ["password", "catalog", "schema"]
 
     def __init__(self, **kw):
 
@@ -50,7 +48,9 @@ class Trino(presto.Presto):
             self.default_schema = kw.get("schema")
 
         if kw.get("password"):
-            kw["auth"] = trino.auth.BasicAuthentication(kw.pop("user"), kw.pop("password"))
+            kw["auth"] = trino.auth.BasicAuthentication(
+                kw.pop("user"), kw.pop("password")
+            )
             kw["http_scheme"] = "https"
 
         if "cert" in kw:

--- a/sqeleton/databases/trino.py
+++ b/sqeleton/databases/trino.py
@@ -53,9 +53,7 @@ class Trino(presto.Presto):
             )
             kw["http_scheme"] = "https"
 
-        if "cert" in kw:
-            cert = kw.pop("cert")
-            self._conn = trino.dbapi.connect(**kw)
+        cert = kw.pop("cert", None)
+        self._conn = trino.dbapi.connect(**kw)
+        if cert is not None:
             self._conn._http_session.verify = cert
-        else:
-            self._conn = trino.dbapi.connect(**kw)


### PR DESCRIPTION
fix https://github.com/erezsh/sqeleton/issues/14

- Most of the files are not mandatory. Those are just instructions and files to spun a Trino cluster using password file authentication. 
- We don't need to bump the Trino version. As I was working those files I though we can bump it.

### New options in server config
If using jdk < 22, new versions of Trino will complain about
> dd-trino  | ERROR: Trino requires -XX:+UnlockDiagnosticVMOptions -XX:G1NumCollectionsKeepPinned=10000000 on Java versions lower than 22.0.2 due to JDK-8329528
https://bugs.openjdk.org/browse/JDK-8329528

#### -XX:+UnlockDiagnosticVMOptions 
Unlocks additional diagnostic options for the JVM.
Here's more info https://github.com/trinodb/trino/pull/12251

#### -XX:G1NumCollectionsKeepPinned
More info https://github.com/trinodb/trino/pull/21999

---

To allow Trino connections with password, I believe two routes would work.

#### Check for "auth" parameter like we have in presto.py
https://github.com/erezsh/sqeleton/blob/01ef6c7ee742aee754a8ea628fc3b6f0ec2d5655/sqeleton/databases/presto.py#L173C1-L174C95

#### Check for password
```python
if kw.get("password"):
    kw["auth"] = trino.auth.BasicAuthentication(
        kw.pop("user"), kw.pop("password")
    )
```

The second method would work for sqlalchemy like conn strings and also when using db_conf dict with **user** and **password**. 

@erezsh I may be missing something, let me know what you think and I can change it to check for **auth** instead. Thank you so much let me work on that one.