### PR TITLE
Disables Snowflake telemetry, connection closing bit faster.

### DIFF
--- a/sqeleton/databases/snowflake.py
+++ b/sqeleton/databases/snowflake.py
@@ -184,7 +184,7 @@ class Snowflake(Database):
             )
 
         self._conn = snowflake.connector.connect(schema=f'"{schema}"', **kw)
-
+        self._conn.telemetry_enabled = False
         self.default_schema = schema
 
     def close(self):


### PR DESCRIPTION
Hey, Snowflake telemetry is enabled by default. Having it disabled make Snowflake querying a bit faster (As i saw, only sends telemetry data when closing connection - but still)